### PR TITLE
Remove deprecated $ensure from concat::fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ keepalived::vrrp_instance:
 
 ```puppet
 class { 'keepalived::global_defs':
-  ensure                  => present,
   notification_email      => 'no@spam.tld',
   notification_email_from => 'no@spam.tld',
   smtp_server             => 'localhost',

--- a/manifests/global_defs.pp
+++ b/manifests/global_defs.pp
@@ -17,19 +17,14 @@
 # $router_id::                Define the router ID.
 #                             Default: undef.
 #
-# $ensure::                   Default: present.
-#
-#
 class keepalived::global_defs(
   $notification_email      = undef,
   $notification_email_from = undef,
   $smtp_server             = undef,
   $smtp_connect_timeout    = undef,
   $router_id               = undef,
-  $ensure                  = present,
 ) inherits keepalived::params {
   concat::fragment { 'keepalived.conf_globaldefs':
-    ensure  => $ensure,
     target  => "${::keepalived::params::config_dir}/keepalived.conf",
     content => template('keepalived/globaldefs.erb'),
     order   => '010',

--- a/manifests/vrrp/instance.pp
+++ b/manifests/vrrp/instance.pp
@@ -47,8 +47,6 @@
 #
 # $virtual_router_id::     Set virtual router id.
 #
-# $ensure::                Default: present.
-#
 # $auth_type::             Set authentication method.
 #                          Default: undef.
 #
@@ -145,7 +143,6 @@ define keepalived::vrrp::instance (
   $state,
   $virtual_router_id,
   $virtual_ipaddress          = undef,
-  $ensure                     = present,
   $auth_type                  = undef,
   $auth_pass                  = undef,
   $track_script               = undef,
@@ -181,7 +178,6 @@ define keepalived::vrrp::instance (
   }
 
   concat::fragment { "keepalived.conf_vrrp_instance_${_name}":
-    ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_instance.erb'),
     order   => '100',

--- a/manifests/vrrp/sync_group.pp
+++ b/manifests/vrrp/sync_group.pp
@@ -4,8 +4,6 @@
 #
 # $group::                 Define vrrp instances to group (Array)
 #
-# $ensure::                Default: present.
-#
 # $notify_script_master::  Define the notify master script.
 #                          Default: undef.
 #
@@ -24,7 +22,6 @@
 #
 define keepalived::vrrp::sync_group (
   $group,
-  $ensure               = present,
   $notify_script_master = undef,
   $notify_script_backup = undef,
   $notify_script_fault  = undef,
@@ -35,7 +32,6 @@ define keepalived::vrrp::sync_group (
   $_name = regsubst($name, '[:\/\n]', '')
 
   concat::fragment { "keepalived.conf_vrrp_sync_group_${_name}":
-    ensure  => $ensure,
     target  => "${::keepalived::config_dir}/keepalived.conf",
     content => template('keepalived/vrrp_sync_group.erb'),
     order   => '050',

--- a/spec/defines/keepalived_vrrp_instance_spec.rb
+++ b/spec/defines/keepalived_vrrp_instance_spec.rb
@@ -283,22 +283,6 @@ describe 'keepalived::vrrp::instance', :type => :define do
     end
   end
 
-  describe 'with parameter: ensure' do
-    let (:params) {
-      mandatory_params.merge({
-        :ensure => '_VALUE_',
-      })
-    }
-
-    it { should create_keepalived__vrrp__instance('_NAME_') }
-    it {
-      should \
-        contain_concat__fragment('keepalived.conf_vrrp_instance__NAME_').with(
-        'ensure' => /_VALUE_/
-      )
-    }
-  end
-
   describe 'with parameter auth_type' do
     let (:params) {
       mandatory_params.merge({


### PR DESCRIPTION
This patch will remove these warning messages:
The $ensure parameter to concat::fragment is deprecated and has no effect.
